### PR TITLE
Fix default ruff rules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,18 +14,18 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+import django
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-import django
-import awl
-
 SRC_DIR = Path(__file__).parent / '../src'
 SRC_DIR = SRC_DIR.resolve()
 sys.path.insert(0, str(SRC_DIR))
 from django.conf import settings  # noqa: E402
+import awl  # noqa: E402
 settings.configure(
     BASE_DIR=str(SRC_DIR / 'awl'),
     INSTALLED_APPS=(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@
 # serve to show the default.
 
 import sys
-import shlex
+from datetime import datetime
 from pathlib import Path
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -19,11 +19,13 @@ from pathlib import Path
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
+import django
+import awl
+
 SRC_DIR = Path(__file__).parent / '../src'
 SRC_DIR = SRC_DIR.resolve()
 sys.path.insert(0, str(SRC_DIR))
-import django
-from django.conf import settings
+from django.conf import settings  # noqa: E402
 settings.configure(
     BASE_DIR=str(SRC_DIR / 'awl'),
     INSTALLED_APPS=(
@@ -64,7 +66,6 @@ master_doc = 'index'
 # General information about the project.
 project = 'Awl'
 
-from datetime import datetime
 author = 'Christopher Trudeau'
 copyright = '2015-%s, %s' % (datetime.now().year, author)
 
@@ -73,7 +74,6 @@ copyright = '2015-%s, %s' % (datetime.now().year, author)
 # built documents.
 #
 # The short X.Y version.
-import awl
 version = awl.__version__
 
 # The full version, including alpha/beta/rc tags.

--- a/extras/SampleSite/app/management/commands/create_test_data.py
+++ b/extras/SampleSite/app/management/commands/create_test_data.py
@@ -14,19 +14,19 @@ class Command(BaseCommand):
         writer = Writer.objects.create(name='Douglas Adams')
         show = Show.objects.create(title='Dirk Gently', writer=writer)
         show.stations.add(nbc, hbo)
-        episode = Episode.objects.create(name='Space Rabbit', show=show)
-        episode = Episode.objects.create(name='Fans of Wet Circles', show=show)
+        _episode = Episode.objects.create(name='Space Rabbit', show=show)
+        _episode = Episode.objects.create(name='Fans of Wet Circles', show=show)
 
         writer = Writer.objects.create(name='G.R.R Martin')
         show = Show.objects.create(title='Game of Thrones', writer=writer)
         show.stations.add(hbo)
-        episode = Episode.objects.create(name='Dragonstone', show=show)
-        episode = Episode.objects.create(name='Stormborn', show=show)
+        _episode = Episode.objects.create(name='Dragonstone', show=show)
+        _episode = Episode.objects.create(name='Stormborn', show=show)
 
         Show.objects.create(title='Episodeless', writer=writer)
 
         show = Show.objects.create(title='Simpsons')
-        episode = Episode.objects.create(name='TreeHouse of Horror III', 
+        _episode = Episode.objects.create(name='TreeHouse of Horror III', 
             show=show)
 
         Episode.objects.create(name='Without Show')

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ def common(session):
 @nox.session(python=["3.8", "3.9"])
 def test320(session):
     common(session)
-    session.install(f"django>=3.2,<4.0")
+    session.install("django>=3.2,<4.0")
     session.run("./load_tests.py", external=True)
 
 
@@ -22,7 +22,7 @@ def test320(session):
 @nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 def test410(session):
     common(session)
-    session.install(f"django>=4.1,<4.2")
+    session.install("django>=4.1,<4.2")
     session.run("./load_tests.py", external=True)
 
 
@@ -30,7 +30,7 @@ def test410(session):
 @nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 def test420(session):
     common(session)
-    session.install(f"django>=4.2,<4.3")
+    session.install("django>=4.2,<4.3")
     session.run("./load_tests.py", external=True)
 
 

--- a/src/awl/decorators.py
+++ b/src/awl/decorators.py
@@ -1,5 +1,6 @@
 # awl.decorators.py
-import logging, json
+import json
+import logging
 from functools import wraps
 
 from django.http import Http404

--- a/src/awl/templatetags/awltags.py
+++ b/src/awl/templatetags/awltags.py
@@ -121,7 +121,7 @@ class AccessorNode(template.Node):
                 return ''
 
             return ref
-        except:  # noqa: E722
+        except Exception:
             # any lookup errors should result in empty
             if self.as_var:
                 context[self.as_var] = ''

--- a/src/awl/templatetags/awltags.py
+++ b/src/awl/templatetags/awltags.py
@@ -121,7 +121,7 @@ class AccessorNode(template.Node):
                 return ''
 
             return ref
-        except:
+        except:  # noqa: E722
             # any lookup errors should result in empty
             if self.as_var:
                 context[self.as_var] = ''

--- a/src/awl/utils.py
+++ b/src/awl/utils.py
@@ -84,7 +84,7 @@ def get_field_names(obj, ignore_auto=True, ignore_relations=True,
                 isinstance(field, OneToOneField)):
             # optimization is killing coverage measure, have to put no-op that
             # does something
-            a = 1; a
+            a = 1; a  # noqa: E702
             continue
 
         if field.name in exclude:

--- a/src/awl/waelsteng.py
+++ b/src/awl/waelsteng.py
@@ -4,7 +4,8 @@
 # module in order to handle some better grouping of items.  New things will
 # need to be explicitly added to docs/waelsteng.rst
 #
-import shutil, tempfile
+import shutil
+import tempfile
 from unittest import TestSuite
 
 from django.conf import settings

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,12 +34,12 @@ class ModelsTest(TestCase):
         self.assertEqual(MoreColours.GREEN, 'g')
 
         # check conversion to django-style choices list
-        l = list(MoreColours)
-        self.assertEqual(len(l), 4)
-        self.assertIn(('r', 'Red'), l)
-        self.assertIn(('b', 'Blueish'), l)
-        self.assertIn(('g', 'Green'), l)
-        self.assertIn(('o', 'Light Orange'), l)
+        more_colours = list(MoreColours)
+        self.assertEqual(len(more_colours), 4)
+        self.assertIn(('r', 'Red'), more_colours)
+        self.assertIn(('b', 'Blueish'), more_colours)
+        self.assertIn(('g', 'Green'), more_colours)
+        self.assertIn(('o', 'Light Orange'), more_colours)
 
         # check gettr method
         self.assertEqual('Red', Colours.get_value('r'))

--- a/tests/test_waelsteng.py
+++ b/tests/test_waelsteng.py
@@ -1,4 +1,7 @@
-import os, tempfile, shutil, unittest
+import os
+import shutil
+import tempfile
+import unittest
 from unittest import mock
 from django.contrib import messages
 from django.test import TestCase, override_settings


### PR DESCRIPTION
% `pipx install ruff`
% `ruff . ` # https://docs.astral.sh/ruff
```
docs/conf.py:14:8: F401 [*] `shlex` imported but unused
docs/conf.py:25:1: E402 Module level import not at top of file
docs/conf.py:26:1: E402 Module level import not at top of file
docs/conf.py:67:1: E402 Module level import not at top of file
docs/conf.py:76:1: E402 Module level import not at top of file
extras/SampleSite/app/management/commands/create_test_data.py:29:9: F841 Local variable `episode` is assigned to but never used
noxfile.py:14:21: F541 [*] f-string without any placeholders
noxfile.py:25:21: F541 [*] f-string without any placeholders
noxfile.py:33:21: F541 [*] f-string without any placeholders
src/awl/decorators.py:2:1: E401 Multiple imports on one line
src/awl/templatetags/awltags.py:124:9: E722 Do not use bare `except`
src/awl/utils.py:87:18: E702 Multiple statements on one line (semicolon)
src/awl/waelsteng.py:7:1: E401 Multiple imports on one line
tests/test_models.py:37:9: E741 Ambiguous variable name: `l`
tests/test_waelsteng.py:1:1: E401 Multiple imports on one line
```
---
% `ruff rule E722 ` # https://realpython.com/the-most-diabolical-python-antipattern
# bare-except (E722)

Derived from the **pycodestyle** linter.

## What it does
Checks for bare `except` catches in `try`-`except` statements.

## Why is this bad?
A bare `except` catches `BaseException` which includes
`KeyboardInterrupt`, `SystemExit`, `Exception`, and others. Catching
`BaseException` can make it hard to interrupt the program (e.g., with
Ctrl-C) and can disguise other problems.

## Example
```python
try:
    raise KeyboardInterrupt("You probably don't mean to break CTRL-C.")
except:
    print("But a bare `except` will ignore keyboard interrupts.")
```

Use instead:
```python
try:
    do_something_that_might_break()
except MoreSpecificException as e:
    handle_error(e)
```

If you actually need to catch an unknown error, use `Exception` which will
catch regular program errors but not important system exceptions.

```python
def run_a_function(some_other_fn):
    try:
        some_other_fn()
    except Exception as e:
        print(f"How exceptional! {e}")
```

## References
- [Python documentation: Exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy)
- [Google Python Style Guide: "Exceptions"](https://google.github.io/styleguide/pyguide.html#24-exceptions)
