### PR TITLE
Merge repeated isinstance() calls

### DIFF
--- a/src/awl/management/commands/print_setting.py
+++ b/src/awl/management/commands/print_setting.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         value = getattr(settings, options['name'])
-        if isinstance(value, list) or isinstance(value, tuple):
+        if isinstance(value, (list, tuple)):
             value = ' '.join(value)
 
         print(value)

--- a/src/awl/utils.py
+++ b/src/awl/utils.py
@@ -77,11 +77,7 @@ def get_field_names(obj, ignore_auto=True, ignore_relations=True,
         if ignore_auto and isinstance(field, AutoField):
             continue
 
-        if ignore_relations and (isinstance(field, ForeignKey) or
-                isinstance(field, ManyToManyField) or
-                isinstance(field, ManyToOneRel) or
-                isinstance(field, OneToOneRel) or
-                isinstance(field, OneToOneField)):
+        if ignore_relations and (isinstance(field, (ForeignKey, ManyToManyField, ManyToOneRel, OneToOneField, OneToOneRel))):
             # optimization is killing coverage measure, have to put no-op that
             # does something
             a = 1; a


### PR DESCRIPTION
% `ruff --select=PLR1701 --fix .`
% `ruff rule PLR1701`
# repeated-isinstance-calls (PLR1701)

Derived from the **Pylint** linter.

Fix is always available.

## What it does
Checks for repeated `isinstance` calls on the same object.

## Why is this bad?
Repeated `isinstance` calls on the same object can be merged into a
single call.

## Example
```python
def is_number(x):
    return isinstance(x, int) or isinstance(x, float) or isinstance(x, complex)
```

Use instead:
```python
def is_number(x):
    return isinstance(x, (int, float, complex))
```

Or, for Python 3.10 and later:

```python
def is_number(x):
    return isinstance(x, int | float | complex)
```

## Options
- `target-version`

## References
- [Python documentation: `isinstance`](https://docs.python.org/3/library/functions.html#isinstance)